### PR TITLE
Added explore command to allow users to install mixins from repo

### DIFF
--- a/bin/sassysass
+++ b/bin/sassysass
@@ -7,7 +7,8 @@ var argument    = process.argv[2],
   install       = require('../lib/commands/install'),
   show          = require('../lib/commands/show'),
   unused        = require('../lib/commands/unused'),
-  help          = require('../lib/commands/help');
+  help          = require('../lib/commands/help'),
+  explore       = require('../lib/commands/explore');
 
 switch (true) {
   case (argument === 'install'):
@@ -30,6 +31,9 @@ switch (true) {
     break;
   case (argument === 'unused'):
     unused(argumentSec);
+    break;
+  case (argument === 'explore'):
+    explore();
     break;
   default:
     help();

--- a/lib/commands/explore.js
+++ b/lib/commands/explore.js
@@ -1,0 +1,69 @@
+var fs              = require('fs'),
+    https            = require('https'),
+    request         = require('request'),
+    write           = require('../write'),
+    path            = require('path'),
+    prompt          = require('prompt'),
+    pkg             = require('../../package.json'),
+    version         = pkg.version,
+    dir             = path.dirname(),
+    mixinsPath      = 'sass/utils',
+    availableMixins = [];
+
+module.exports = function explore() {
+  var options = {
+    url: 'https://api.github.com/repositories/35896497/contents/utils/mixins',
+    method: 'GET',
+    headers: {
+      'User-Agent':   'Super Agent/0.0.1',
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  };
+
+  // API Github requests user agent
+  console.log('Fetching mixins...\n\n'.red);
+  request(options, function (error, response, body) {
+    if (!error) {
+      JSON.parse(body).forEach(function(e,i,a) {
+        availableMixins.push(e.name);
+      });
+      startPrompt(availableMixins);
+    }
+  });
+
+  function startPrompt(json) {
+    prompt.message = 'SassySass'.magenta;
+    prompt.delimiter = ' ';
+
+    prompt.start();
+
+    prompt.get({
+      properties: {
+        mixinSelected : {
+          description: 'What mixin would you like to install?\n'.red + json.map(function(name, index) { return index + '. ' + name; }).join('\n').white + '\n'
+        }
+      }
+    }, function (err, result) {
+      var mixinFile = availableMixins[result.mixinSelected];
+      console.log(mixinFile);
+      var file = fs.createWriteStream(dir + '/' + mixinsPath + '/mixins/' + mixinFile);
+      var req = https.get('https://raw.githubusercontent.com/ryanburgess/sassysass/master/utils/mixins/' + mixinFile, function(response) {
+        response.pipe(file);
+        file.on('finish', function() {
+          file.close(function(err) {
+            fs.appendFile(dir + '/' + mixinsPath + '/_mixins.scss', '@import \"mixins/' + mixinFile.substr(1).split('.scss')[0] + '\";\n', function (err) {
+              if (err) {
+                console.log(err);
+              }
+            });
+            console.log('\n Mixin ' + mixinFile + ' successfully added.'.magenta);
+          });  // close() is async, call cb after close completes.
+        });
+      }).on('error', function(err) { // Handle errors
+        fs.unlink(dir + mixinsPath); // Delete the file async. (But we don't check the result)
+        console.log(err);
+      });
+    });
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "gulp-jsonlint": "^1.1.0",
     "gulp-nodeunit": "0.0.5",
     "jshint-stylish": "^2.0.0",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "request": "~2.60.0",
+    "https": "~1.0.0"
   },
   "peerDependencies": {},
   "homepage": "https://github.com/ryanburgess/sassysass#readme"


### PR DESCRIPTION
I made a small prototype that would allow users to see a list of mixins from our repository and then have a choice to download them. I called the command `explore` but that can change. 

I set it up so it makes an AJAX request to the [Github API `contents` endpoint](https://developer.github.com/v3/repos/contents/) and I iterate through the [utils/mixins folder on this repository](https://github.com/ryanburgess/sassysass/tree/master/utils/mixins). 

<img width="383" alt="screen shot 2015-07-27 at 11 03 41 pm" src="https://cloud.githubusercontent.com/assets/2054339/8925225/f3e965c8-34ba-11e5-80d4-b6904e50091a.png">

After that, the user can choose a number (exactly like how @w4ilun made the `mixin` command). Once a user has selected a mixin of choice, it will download the file to the mixins folder under utils, and also add it as an import statement to `_mixins.scss`.

I didn't write tests and there are some interesting edge cases that I'm still working out to solve such as checking if the mixin already exists, etc. If you guys have thoughts on what I can do to make this merge-ready please let me know! Thanks :)
