### PR TITLE
Add text-align SCSS mixin which allows for the inline and inline-block…

### DIFF
--- a/utils/_mixins.scss
+++ b/utils/_mixins.scss
@@ -50,6 +50,7 @@
 @import "mixins/box-model";
 @import "mixins/clearfix";
 @import "mixins/inline-block";
+@import "mixins/align-text";
 
 // ----------------------------------------------------------------------
 

--- a/utils/mixins/_align-text.scss
+++ b/utils/mixins/_align-text.scss
@@ -1,0 +1,10 @@
+// ----------------------------------------------------------------------
+
+  // Align inline and inline-block child elements
+   // example: @include align(center);
+
+// ----------------------------------------------------------------------
+
+@mixin align($direction){
+	text-align:$direction;
+}


### PR DESCRIPTION
… elements to be aligned

The mixin which is located in the utils folder when applied to the parent element will cause the child elements to be aligned based on the input given to the mixin.

Input options: left, right, center
